### PR TITLE
Fix package export syntax and file paths

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
-import { AccessToken } from "./lib/AccessToken";
-import { AccessKey } from "./lib/AccessKey";
-import { ClientCredentialsGrantHandler } from "./lib/ClientCredentialsGrantHandler";
-import { ClientCredentialsOptions } from "./lib/ClientCredentialsOptions";
-import { createClientCredentialsHandler } from "./lib/ClientCredentialsGrantHandlerFactory";
+import { AccessToken } from "./lib/AccessToken.js";
+import { AccessKey } from "./lib/AccessKey.js";
+import { ClientCredentialsGrantHandler } from "./lib/ClientCredentialsGrantHandler.js";
+import { ClientCredentialsOptions } from "./lib/ClientCredentialsOptions.js";
+import { createClientCredentialsHandler } from "./lib/ClientCredentialsGrantHandlerFactory.js";
 
 export { AccessToken, AccessKey, ClientCredentialsGrantHandler, ClientCredentialsOptions, createClientCredentialsHandler };

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,7 @@
-// import { AccessToken } from "./lib/AccessToken";
-// import { AccessKey } from "./lib/AccessKey";
-// import { ClientCredentialsGrantHandler } from "./lib/ClientCredentialsGrantHandler";
-// import { ClientCredentialsOptions } from "./lib/ClientCredentialsOptions";
-// import { createClientCredentialsHandler } from "./lib/ClientCredentialsGrantHandlerFactory";
-// //export {AccessKey, AccessToken, ClientCredentialsGrantHandler, ClientCredentialsOptions, createClientCredentialsHandler}
+import { AccessToken } from "./lib/AccessToken";
+import { AccessKey } from "./lib/AccessKey";
+import { ClientCredentialsGrantHandler } from "./lib/ClientCredentialsGrantHandler";
+import { ClientCredentialsOptions } from "./lib/ClientCredentialsOptions";
+import { createClientCredentialsHandler } from "./lib/ClientCredentialsGrantHandlerFactory";
 
-export * as  AccessToken from './lib/AccessToken';
-export * as  AccessKey from './lib/AccessKey';
-export * as  ClientCredentialsGrantHandler from './lib/ClientCredentialsGrantHandler';
-export * as  ClientCredentialsOptions from './lib/ClientCredentialsOptions';
-export * as  createClientCredentialsHandler from './lib/ClientCredentialsGrantHandlerFactory';
+export { AccessToken, AccessKey, ClientCredentialsGrantHandler, ClientCredentialsOptions, createClientCredentialsHandler };

--- a/lib/AccessKey.ts
+++ b/lib/AccessKey.ts
@@ -1,4 +1,4 @@
-import { JWK } from "./JWK";
+import { JWK } from "./JWK.js";
 
 export interface AccessKey {
     // The account ID associated to the application

--- a/lib/ClientCredentialsGrantHandler.ts
+++ b/lib/ClientCredentialsGrantHandler.ts
@@ -1,7 +1,7 @@
 import fetch from 'isomorphic-fetch';
 import { KEYUTIL, KJUR } from 'jsrsasign';
-import { ClientCredentialsOptions } from './ClientCredentialsOptions';
-import { AccessToken } from './AccessToken';
+import { ClientCredentialsOptions } from './ClientCredentialsOptions.js';
+import { AccessToken } from './AccessToken.js';
 import { DomainUtil } from './DomainUtil.js';
 
 export class ClientCredentialsGrantHandler {

--- a/lib/ClientCredentialsGrantHandlerFactory.ts
+++ b/lib/ClientCredentialsGrantHandlerFactory.ts
@@ -1,5 +1,5 @@
-import { ClientCredentialsGrantHandler } from "./ClientCredentialsGrantHandler";
-import { ClientCredentialsOptions } from "./ClientCredentialsOptions";
+import { ClientCredentialsGrantHandler } from "./ClientCredentialsGrantHandler.js";
+import { ClientCredentialsOptions } from "./ClientCredentialsOptions.js";
 
 export function createClientCredentialsHandler(accessKey: string, servicePrincipalKey: string) : ClientCredentialsGrantHandler {
     let options: ClientCredentialsOptions = {

--- a/lib/ClientCredentialsOptions.ts
+++ b/lib/ClientCredentialsOptions.ts
@@ -1,4 +1,4 @@
-import { AccessKey } from "./AccessKey";
+import { AccessKey } from "./AccessKey.js";
 
 export interface ClientCredentialsOptions {
     // The service principal key for the associated service principal user


### PR DESCRIPTION
There are errors when using / referencing the package because of the export syntax and file paths were missing '.js'. 